### PR TITLE
feat: 유저 API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
+        "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -1928,6 +1929,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-validator/node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2630,6 +2653,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
+    "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/prisma/migrations/20250731021749_init/migration.sql
+++ b/prisma/migrations/20250731021749_init/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `usersId` on the `Subtasks` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Subtasks" DROP CONSTRAINT "Subtasks_usersId_fkey";
+
+-- AlterTable
+ALTER TABLE "Subtasks" DROP COLUMN "usersId",
+ADD COLUMN     "userId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Tasks" ALTER COLUMN "description" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Subtasks" ADD CONSTRAINT "Subtasks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250731052951_init/migration.sql
+++ b/prisma/migrations/20250731052951_init/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `usersId` on the `Subtasks` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Subtasks" DROP CONSTRAINT "Subtasks_usersId_fkey";
+
+-- AlterTable
+ALTER TABLE "Subtasks" DROP COLUMN "usersId",
+ADD COLUMN     "userId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Tasks" ALTER COLUMN "description" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Subtasks" ADD CONSTRAINT "Subtasks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "Users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,7 +2,93 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
-  // 1. Projects
+  // ✅ 1. Users 테이블에 사용자 데이터 먼저 삽입
+  await prisma.users.createMany({
+    data: [
+      {
+        id: 1,
+        email: 'user1@example.com',
+        name: 'User One',
+        password: 'hashed1',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 2,
+        email: 'user2@example.com',
+        name: 'User Two',
+        password: 'hashed2',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 3,
+        email: 'user3@example.com',
+        name: 'User Three',
+        password: 'hashed3',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 4,
+        email: 'user4@example.com',
+        name: 'User Four',
+        password: 'hashed4',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 5,
+        email: 'user5@example.com',
+        name: 'User Five',
+        password: 'hashed5',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 6,
+        email: 'user6@example.com',
+        name: 'User Six',
+        password: 'hashed6',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 7,
+        email: 'user7@example.com',
+        name: 'User Seven',
+        password: 'hashed7',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 8,
+        email: 'user8@example.com',
+        name: 'User Eight',
+        password: 'hashed8',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 9,
+        email: 'user9@example.com',
+        name: 'User Nine',
+        password: 'hashed9',
+        profileImage: '',
+        provider: 'local',
+      },
+      {
+        id: 10,
+        email: 'user10@example.com',
+        name: 'User Ten',
+        password: 'hashed10',
+        profileImage: '',
+        provider: 'local',
+      },
+    ],
+  });
+
+  // ✅ 2. Projects 테이블에 프로젝트 데이터 삽입 (Users의 id를 참조)
   await prisma.projects.createMany({
     data: [
       { id: 1, name: 'Project Apollo', description: 'AI 연구 프로젝트', creatorId: 1 },
@@ -11,7 +97,7 @@ async function main() {
     ],
   });
 
-  // 2. Project_members (creator 포함 + 초대 수락한 유저만)
+  // ✅ 3. Project_members 테이블에 프로젝트 참여자 데이터 삽입
   await prisma.project_members.createMany({
     data: [
       { id: 1, projectId: 1, userId: 1 },
@@ -26,10 +112,9 @@ async function main() {
     ],
   });
 
-  // 3. Invitations (accepted/pending 포함, token 추가됨)
+  // ✅ 4. Invitations 테이블에 초대 데이터 삽입
   await prisma.invitations.createMany({
     data: [
-      // Project 1
       {
         id: 1,
         projectId: 1,
@@ -57,16 +142,7 @@ async function main() {
         acceptedAt: new Date(),
         token: 'token-1-6',
       },
-      {
-        id: 4,
-        projectId: 1,
-        invitorId: 1,
-        inviteeId: 7,
-        status: 'pending',
-        token: 'token-1-7',
-      },
-
-      // Project 2
+      { id: 4, projectId: 1, invitorId: 1, inviteeId: 7, status: 'pending', token: 'token-1-7' },
       {
         id: 5,
         projectId: 2,
@@ -85,16 +161,7 @@ async function main() {
         acceptedAt: new Date(),
         token: 'token-2-8',
       },
-      {
-        id: 7,
-        projectId: 2,
-        invitorId: 2,
-        inviteeId: 9,
-        status: 'pending',
-        token: 'token-2-9',
-      },
-
-      // Project 3
+      { id: 7, projectId: 2, invitorId: 2, inviteeId: 9, status: 'pending', token: 'token-2-9' },
       {
         id: 8,
         projectId: 3,
@@ -104,20 +171,14 @@ async function main() {
         acceptedAt: new Date(),
         token: 'token-3-9',
       },
-      {
-        id: 9,
-        projectId: 3,
-        invitorId: 3,
-        inviteeId: 10,
-        status: 'pending',
-        token: 'token-3-10',
-      },
+      { id: 9, projectId: 3, invitorId: 3, inviteeId: 10, status: 'pending', token: 'token-3-10' },
     ],
   });
 }
 
+// 시드 데이터 실행
 main()
-  .then(() => console.log('🌱 Seed data inserted successfully!'))
+  .then(() => console.log('🌱 시드 데이터가 성공적으로 삽입되었습니다!'))
   .catch((e) => {
     console.error(e);
     process.exit(1);

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,6 @@ app.use(
   })
 );
 app.use(express.json());
-app.use(cookieParser());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 app.use(passport.initialize());

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
 
-const db = new PrismaClient();
+const prisma = new PrismaClient();
 
-export default db;
+export default prisma;

--- a/src/controllers/user-controller.ts
+++ b/src/controllers/user-controller.ts
@@ -29,6 +29,8 @@ export const updateMyInfoController: RequestHandler = async (req, res, next) => 
         return handleError(next, err, err.message, statusCode.badRequest);
       if (err.message === '현재 비밀번호가 일치하지 않습니다.')
         return handleError(next, err, err.message, statusCode.unauthorized);
+      if (err.message === 'Google 로그인 사용자는 비밀번호를 변경할 수 없습니다.')
+        return handleError(next, err, err.message, statusCode.badRequest);
       if (err.message === errorMsg.userNotFound)
         return handleError(next, err, err.message, statusCode.notFound);
     }

--- a/src/controllers/user-controller.ts
+++ b/src/controllers/user-controller.ts
@@ -1,0 +1,84 @@
+import { RequestHandler } from 'express';
+import UserService from '../services/user-service';
+import { handleError, statusCode, errorMsg } from '../middlewares/error-handler';
+
+const userService = new UserService();
+
+export const getMyInfoController: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return handleError(next, null, errorMsg.loginRequired, statusCode.unauthorized);
+
+    const user = await userService.getMyInfo(userId);
+    res.status(statusCode.success).json(user);
+  } catch {
+    handleError(next, null, errorMsg.getUserFailed, statusCode.internalServerError);
+  }
+};
+
+export const updateMyInfoController: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return handleError(next, null, errorMsg.loginRequired, statusCode.unauthorized);
+
+    const updatedUser = await userService.updateMyInfo(userId, req.body);
+    res.status(statusCode.success).json(updatedUser);
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      if (err.message === '현재 비밀번호가 필요합니다.')
+        return handleError(next, err, err.message, statusCode.badRequest);
+      if (err.message === '현재 비밀번호가 일치하지 않습니다.')
+        return handleError(next, err, err.message, statusCode.unauthorized);
+      if (err.message === errorMsg.userNotFound)
+        return handleError(next, err, err.message, statusCode.notFound);
+    }
+    handleError(next, err, errorMsg.updateUserFailed, statusCode.internalServerError);
+  }
+};
+
+export const getMyProjectsController: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return handleError(next, null, errorMsg.loginRequired, statusCode.unauthorized);
+
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 10;
+    const order = req.query.order === 'desc' ? 'desc' : 'asc';
+    const orderBy = req.query.order_by === 'name' ? 'name' : 'createdAt';
+
+    const result = await userService.getMyProjects(userId, {
+      page,
+      limit,
+      order,
+      orderBy,
+    });
+
+    res.status(statusCode.success).json(result);
+  } catch (err) {
+    handleError(next, err, '프로젝트 목록 조회 실패', statusCode.internalServerError);
+  }
+};
+
+export const getMyTasksController: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return handleError(next, null, errorMsg.loginRequired, statusCode.unauthorized);
+
+    const filter = {
+      from: req.query.from ? String(req.query.from) : undefined,
+      to: req.query.to ? String(req.query.to) : undefined,
+      projectId: req.query.project_id ? Number(req.query.project_id) : undefined,
+      status: req.query.status
+        ? (String(req.query.status) as 'todo' | 'inProgress' | 'done')
+        : undefined,
+      assignee: req.query.assignee ? Number(req.query.assignee) : undefined,
+      keyword: req.query.keyword ? String(req.query.keyword) : undefined,
+    };
+
+    const tasks = await userService.getMyTasks(userId, filter);
+
+    res.status(statusCode.success).json(tasks);
+  } catch (err) {
+    handleError(next, err, '할 일 목록 조회 실패', statusCode.internalServerError);
+  }
+};

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -11,6 +11,7 @@ export const statusCode = {
 } as const;
 
 export const errorMsg = {
+  // Project 관련
   maxProjectLimit: '프로젝트는 최대 5개까지 생성할 수 있습니다.',
   invalidProjectId: '유효한 프로젝트 ID가 아닙니다.',
   projectNotFound: '프로젝트를 찾을 수 없습니다.',
@@ -18,9 +19,18 @@ export const errorMsg = {
   getProjectFailed: '프로젝트 조회 중 오류가 발생했습니다.',
   updateProjectFailed: '프로젝트 수정 중 오류가 발생했습니다.',
   noPermissionToUpdate: '프로젝트 수정 권한이 없습니다.',
+
+  // User 관련
+  badRequest: '잘못된 요청입니다',
+  loginRequired: '로그인이 필요합니다',
+  tokenExpired: '토큰 만료',
+  userNotFound: '존재하지 않는 유저입니다',
+  getUserFailed: '사용자 정보 조회 중 오류가 발생했습니다.',
+  updateUserFailed: '사용자 정보 수정 중 오류가 발생했습니다.',
+
+  // 공통
   serverError: '서버 내부 오류가 발생했습니다.',
   wrongRequestFormat: '잘못된 요청 형식 입니다.',
-  loginRequired: '로그인이 필요합니다.',
   accessDenied: '접근 권한이 없습니다.',
   dataNotFound: '해당 데이터를 찾을 수 없습니다.',
 } as const;
@@ -47,7 +57,8 @@ export const errorHandler = (
   const message = err.message || errorMsg.serverError;
 
   res.status(status).json({
-    success: false,
     message,
   });
 };
+
+export default errorHandler;

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -27,6 +27,7 @@ export const errorMsg = {
   userNotFound: '존재하지 않는 유저입니다',
   getUserFailed: '사용자 정보 조회 중 오류가 발생했습니다.',
   updateUserFailed: '사용자 정보 수정 중 오류가 발생했습니다.',
+  noPermissionToUpdateUser: '사용자 정보 수정 권한이 없습니다.',
 
   // 공통
   serverError: '서버 내부 오류가 발생했습니다.',

--- a/src/middlewares/validation.ts
+++ b/src/middlewares/validation.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express';
+import { validationResult } from 'express-validator';
+import { statusCode } from './error-handler';
+
+export const validateRequest = (req: Request, res: Response, next: NextFunction) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(statusCode.badRequest).json({ message: errors.array()[0].msg });
+  }
+  next();
+};

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -1,4 +1,4 @@
-import prisma from '../lib/client';
+import prisma from '../config/db';
 import { Users, Projects, Tasks, Prisma } from '@prisma/client';
 
 class UserRepository {

--- a/src/repositories/user-repository.ts
+++ b/src/repositories/user-repository.ts
@@ -1,0 +1,128 @@
+import prisma from '../lib/client';
+import { Users, Projects, Tasks, Prisma } from '@prisma/client';
+
+class UserRepository {
+  async findById(userId: number): Promise<Users | null> {
+    return prisma.users.findUnique({ where: { id: userId } });
+  }
+
+  async update(userId: number, data: Partial<Users>): Promise<Users> {
+    return prisma.users.update({
+      where: { id: userId },
+      data,
+    });
+  }
+
+  async countProjectsByUser(userId: number): Promise<number> {
+    return prisma.project_members.count({
+      where: { userId },
+    });
+  }
+
+  async findProjectsByUser(
+    userId: number,
+    options: {
+      skip: number;
+      take: number;
+      orderBy: Prisma.ProjectsOrderByWithRelationInput;
+    }
+  ): Promise<
+    (Projects & {
+      memberCount: number;
+      todoCount: number;
+      inProgressCount: number;
+      doneCount: number;
+    })[]
+  > {
+    const projects = await prisma.projects.findMany({
+      where: {
+        projectMembers: {
+          some: {
+            userId,
+          },
+        },
+      },
+      skip: options.skip,
+      take: options.take,
+      orderBy: options.orderBy,
+      include: {
+        projectMembers: true,
+        tasks: true,
+      },
+    });
+
+    return projects.map((project) => {
+      const memberCount = project.projectMembers.length;
+      const todoCount = project.tasks.filter((t) => t.status === 'todo').length;
+      const inProgressCount = project.tasks.filter((t) => t.status === 'inProgress').length;
+      const doneCount = project.tasks.filter((t) => t.status === 'done').length;
+
+      return {
+        ...project,
+        memberCount,
+        todoCount,
+        inProgressCount,
+        doneCount,
+      };
+    });
+  }
+
+  async findTasksByUser(
+    userId: number,
+    filter: {
+      from?: string;
+      to?: string;
+      projectId?: number;
+      status?: 'todo' | 'inProgress' | 'done';
+      assignee?: number;
+      keyword?: string;
+    }
+  ): Promise<
+    (Tasks & {
+      user: Pick<Users, 'id' | 'name' | 'email' | 'profileImage'> | null;
+      taskTags: {
+        tag: { id: number; tag: string };
+      }[];
+      taskFiles: { id: number; fileUrl: string }[];
+    })[]
+  > {
+    const where: Prisma.TasksWhereInput = {
+      ...(filter.assignee ? { userId: filter.assignee } : { userId }),
+      projectId: filter.projectId,
+      status: filter.status,
+      ...(filter.keyword
+        ? {
+            title: {
+              contains: filter.keyword,
+              mode: 'insensitive',
+            },
+          }
+        : {}),
+      ...(filter.from || filter.to
+        ? {
+            createdAt: {
+              ...(filter.from ? { gte: new Date(filter.from) } : {}),
+              ...(filter.to ? { lte: new Date(filter.to) } : {}),
+            },
+          }
+        : {}),
+    };
+
+    return prisma.tasks.findMany({
+      where,
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, profileImage: true },
+        },
+        taskTags: {
+          include: {
+            tag: true,
+          },
+        },
+        taskFiles: true,
+      },
+    });
+  }
+}
+
+export default UserRepository;

--- a/src/routes/index-route.ts
+++ b/src/routes/index-route.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import memberRouter from './member-route';
 import authRouter from './auth-route';
 import taskRouter from './task-route';
+import userRouter from './user-route';
 
 const router = Router();
 
 router.use('/', memberRouter);
 router.use('/auth', authRouter);
+router.use('/users', userRouter);
 router.use('/', taskRouter);
 
 export default router;

--- a/src/routes/index-route.ts
+++ b/src/routes/index-route.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
 import memberRouter from './member-route';
 import authRouter from './auth-route';
-import taskRouter from './task-route';
 import userRouter from './user-route';
-
+import taskRouter from './task-route';
 const router = Router();
 
 router.use('/', memberRouter);

--- a/src/routes/user-route.ts
+++ b/src/routes/user-route.ts
@@ -1,0 +1,50 @@
+// src/routes/user-route.ts
+import express from 'express';
+import passport from 'passport';
+import { body } from 'express-validator';
+import { validateRequest } from '../middlewares/validation';
+import {
+  getMyInfoController,
+  updateMyInfoController,
+  getMyProjectsController,
+  getMyTasksController,
+} from '../controllers/user-controller';
+
+const router = express.Router();
+
+router.get('/me', passport.authenticate('access-token', { session: false }), getMyInfoController);
+
+router.patch(
+  '/me',
+  passport.authenticate('access-token', { session: false }),
+  [
+    body('email').optional().isEmail().withMessage('이메일 형식이 올바르지 않습니다.'),
+    body('name').optional().isString().withMessage('이름은 문자열이어야 합니다.'),
+    body('profileImage')
+      .optional({ nullable: true })
+      .isURL()
+      .withMessage('이미지 URL이 유효하지 않습니다.'),
+    body('currentPassword').optional().isString(),
+    body('newPassword')
+      .optional()
+      .isString()
+      .isLength({ min: 8 })
+      .withMessage('비밀번호는 최소 8자 이상이어야 합니다.'),
+  ],
+  validateRequest,
+  updateMyInfoController
+);
+
+router.get(
+  '/me/projects',
+  passport.authenticate('access-token', { session: false }),
+  getMyProjectsController
+);
+
+router.get(
+  '/me/tasks',
+  passport.authenticate('access-token', { session: false }),
+  getMyTasksController
+);
+
+export default router;

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -44,7 +44,14 @@ class UserService {
 
     let hashedPassword: string | undefined;
 
-    if (data.newPassword) {
+    // 💡 provider가 google일 경우 비밀번호 변경 차단
+    if (user.provider === 'google') {
+      if (data.newPassword || data.currentPassword) {
+        throw new Error('Google 로그인 사용자는 비밀번호를 변경할 수 없습니다.');
+      }
+    }
+
+    if (user.provider === 'email' && data.newPassword) {
       if (!data.currentPassword) throw new Error('현재 비밀번호가 필요합니다.');
       const isMatch = await bcrypt.compare(data.currentPassword, user.password);
       if (!isMatch) throw new Error('현재 비밀번호가 일치하지 않습니다.');

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,0 +1,97 @@
+import bcrypt from 'bcrypt';
+import UserRepository from '../repositories/user-repository';
+import { errorMsg } from '../middlewares/error-handler';
+import { Users, Projects } from '@prisma/client';
+
+interface UpdateUserDto {
+  email?: string;
+  name?: string;
+  profileImage?: string | null;
+  currentPassword?: string;
+  newPassword?: string;
+}
+
+interface ProjectListOptions {
+  page: number;
+  limit: number;
+  order: 'asc' | 'desc';
+  orderBy: 'createdAt' | 'name';
+}
+
+interface TaskFilterOptions {
+  from?: string;
+  to?: string;
+  projectId?: number;
+  status?: 'todo' | 'inProgress' | 'done';
+  assignee?: number;
+  keyword?: string;
+}
+
+class UserService {
+  private userRepository = new UserRepository();
+
+  async getMyInfo(userId: number) {
+    const user = await this.userRepository.findById(userId);
+    if (!user) throw new Error(errorMsg.userNotFound);
+
+    const { password: _password, ...safeUser } = user;
+    return safeUser;
+  }
+
+  async updateMyInfo(userId: number, data: UpdateUserDto) {
+    const user = await this.userRepository.findById(userId);
+    if (!user) throw new Error(errorMsg.userNotFound);
+
+    let hashedPassword: string | undefined;
+
+    if (data.newPassword) {
+      if (!data.currentPassword) throw new Error('현재 비밀번호가 필요합니다.');
+      const isMatch = await bcrypt.compare(data.currentPassword, user.password);
+      if (!isMatch) throw new Error('현재 비밀번호가 일치하지 않습니다.');
+
+      hashedPassword = await bcrypt.hash(data.newPassword, 10);
+    }
+
+    const updateData: Partial<Users> = {};
+    if (data.email) updateData.email = data.email;
+    if (data.name) updateData.name = data.name;
+    if (data.profileImage !== undefined) updateData.profileImage = data.profileImage ?? '';
+    if (hashedPassword) updateData.password = hashedPassword;
+
+    const updatedUser = await this.userRepository.update(userId, updateData);
+    const { password: _password, ...safeUser } = updatedUser;
+    return safeUser;
+  }
+
+  async getMyProjects(
+    userId: number,
+    options: ProjectListOptions
+  ): Promise<{
+    data: (Projects & {
+      memberCount: number;
+      todoCount: number;
+      inProgressCount: number;
+      doneCount: number;
+    })[];
+    total: number;
+  }> {
+    const skip = (options.page - 1) * options.limit;
+
+    const [total, projects] = await Promise.all([
+      this.userRepository.countProjectsByUser(userId),
+      this.userRepository.findProjectsByUser(userId, {
+        skip,
+        take: options.limit,
+        orderBy: { [options.orderBy]: options.order },
+      }),
+    ]);
+
+    return { data: projects, total };
+  }
+
+  async getMyTasks(userId: number, filter: TaskFilterOptions) {
+    return this.userRepository.findTasksByUser(userId, filter);
+  }
+}
+
+export default UserService;


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
- 인증 미들웨어를 통한 로그인 사용자 정보 조회 기능
- 사용자의 프로젝트 및 할 일 목록 조회 API  페이징, 필터링, 정렬 기능
- 유저 정보 수정 시 입력값 검증(Validation) 추가

## ❔ 이유
- 계정의 안전성과 보안성을 강화하기 위해 validation을 추가 하였습니다.

## 💬 리뷰어에게
- seed 사용이 낯설어서 프로젝트와 할 일 목록이 제대로 조회가 되는지 한 번 더 결과 확인 해봐야 할 것 같습니다.