### PR TITLE
Fix: 하위 할 일 에러처리, 라우트 통일, passport 테스트 완료

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,6 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import routes from './routes/index-route';
 import passport from 'passport';
-import subtaskRouter from './routes/subtask-route';
 import { errorHandler } from './middlewares/error-handler';
 
 const app = express();
@@ -22,7 +21,6 @@ app.use(passport.initialize());
 
 // 라우터 등록
 app.use('/', routes);
-app.use('/subtasks', subtaskRouter);
 
 // 에러 미들웨어 등록
 app.use(errorHandler);

--- a/src/controllers/subtask-controller.ts
+++ b/src/controllers/subtask-controller.ts
@@ -6,16 +6,13 @@ import { handleError, errorMsg, statusCode } from '../middlewares/error-handler'
 
 async function createSubtask(req: Request, res: Response, next: NextFunction) {
   try {
-    if (!req.user) {
-      const authError = new Error('Unauthorized: User not authenticated');
-      return handleError(next, authError, errorMsg.accessDenied, statusCode.forbidden);
-    }
+    const user = req.user as Express.User;
     const taskId = Number(req.params.taskId);
     if (isNaN(taskId)) {
       const validationError = new Error('Invalid TaskId');
-      return handleError(next, validationError, errorMsg.dataNotFound, statusCode.badRequest);
+      return handleError(next, validationError, errorMsg.invalidTaskId, statusCode.badRequest);
     }
-    const createSubtaks = await subtaskService.createSubtask(req.user.id, taskId, req.body);
+    const createSubtaks = await subtaskService.createSubtask(user.id, taskId, req.body);
     res.status(201).json(createSubtaks);
   } catch (err) {
     next(err);
@@ -26,52 +23,48 @@ async function createSubtask(req: Request, res: Response, next: NextFunction) {
 
 async function getListSubtasks(req: Request, res: Response, next: NextFunction) {
   try {
-    if (!req.user) {
-      const authError = new Error('Unauthorized: User not authenticated');
-      return handleError(next, authError, errorMsg.accessDenied, statusCode.forbidden);
-    }
+    const user = req.user as Express.User;
     const taskId = Number(req.params.taskId);
     const page = Number(req.query.page as string) || 1;
     const limit = Number(req.query.limit as string) || 10;
     if (isNaN(taskId) || isNaN(page) || isNaN(limit)) {
       const validationError = new Error('Invalid request parameters');
-      return handleError(next, validationError, errorMsg.dataNotFound, statusCode.badRequest);
+      return handleError(next, validationError, errorMsg.wrongRequestFormat, statusCode.badRequest);
     }
-    const subtaskList = await subtaskService.getListSubtasks(req.user.id, taskId, page, limit);
+    const subtaskList = await subtaskService.getListSubtasks(user.id, taskId, page, limit);
     res.json(subtaskList);
   } catch (err) {
     next(err);
   }
 }
 
-/* subtask 상세 조회
+//  subtask 상세 조회
+
 async function getDetail(req: Request, res: Response, next: NextFunction) {
   try {
-    const subtaskId = Number(req.params.subtaskId);
-    if(isNaN(subtaskId)){
-      return handleError(next, error, errorMsg.requestError, statusCode.badRequest)
-    }
-    const subtask = await subtaskService.getDetail(req.user.id, subtaskId);
-    res.json(subtask);
-  } catch (err) {
-
-  }
-}
-*/
-
-// subtask 업데이트
-async function updateSubtask(req: Request, res: Response, next: NextFunction) {
-  try {
-    if (!req.user) {
-      const authError = new Error('Unauthorized: User not authenticated');
-      return handleError(next, authError, errorMsg.accessDenied, statusCode.forbidden);
-    }
+    const user = req.user as Express.User;
     const subtaskId = Number(req.params.subtaskId);
     if (isNaN(subtaskId)) {
       const validationError = new Error('Invalid SubtaskId');
       return handleError(next, validationError, errorMsg.dataNotFound, statusCode.badRequest);
     }
-    const subtask = await subtaskService.updateSubtask(req.user.id, subtaskId, req.body);
+    const subtask = await subtaskService.getDetail(user.id, subtaskId);
+    res.json(subtask);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// subtask 업데이트
+async function updateSubtask(req: Request, res: Response, next: NextFunction) {
+  try {
+    const user = req.user as Express.User;
+    const subtaskId = Number(req.params.subtaskId);
+    if (isNaN(subtaskId)) {
+      const validationError = new Error('Invalid SubtaskId');
+      return handleError(next, validationError, errorMsg.dataNotFound, statusCode.badRequest);
+    }
+    const subtask = await subtaskService.updateSubtask(user.id, subtaskId, req.body);
     res.status(200).json(subtask);
   } catch (err) {
     next(err);
@@ -82,20 +75,17 @@ async function updateSubtask(req: Request, res: Response, next: NextFunction) {
 
 async function deleteSubtask(req: Request, res: Response, next: NextFunction) {
   try {
-    if (!req.user) {
-      const authError = new Error('Unauthorized: User not authenticated');
-      return handleError(next, authError, errorMsg.accessDenied, statusCode.forbidden);
-    }
+    const user = req.user as Express.User;
     const subtaskId = Number(req.params.subtaskId);
     if (isNaN(subtaskId)) {
       const validationError = new Error('Invalid SubtaskId');
       return handleError(next, validationError, errorMsg.dataNotFound, statusCode.badRequest);
     }
-    await subtaskService.deleteSubtask(req.user.id, subtaskId);
+    await subtaskService.deleteSubtask(user.id, subtaskId);
     res.status(204).send();
   } catch (err) {
     next(err);
   }
 }
 
-export { createSubtask, getListSubtasks, updateSubtask, deleteSubtask };
+export { createSubtask, getListSubtasks, getDetail, updateSubtask, deleteSubtask };

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -34,6 +34,7 @@ export const errorMsg = {
   wrongRequestFormat: '잘못된 요청 형식 입니다.',
   accessDenied: '접근 권한이 없습니다.',
   dataNotFound: '해당 데이터를 찾을 수 없습니다.',
+  invalidTaskId: '유효한 할 일 ID가 아닙니다.',
 } as const;
 
 export const handleError = (

--- a/src/repositories/subtask-repository.ts
+++ b/src/repositories/subtask-repository.ts
@@ -1,13 +1,5 @@
 import db from '../config/db';
 import { Prisma } from '@prisma/client';
-// taskId 필요
-// createSubtaks
-// findManyWithfilter
-
-// subtasksid 활용
-// findById
-// update
-// delete
 
 export const subtaskRepository = {
   // subtask 생성

--- a/src/repositories/task-repository.ts
+++ b/src/repositories/task-repository.ts
@@ -4,6 +4,13 @@ import { CreateTaskInput, GetAllTaskfilter, UpdateTaskInput } from '../utils/dto
 import { CreateCommentRequest } from '../utils/dtos/comment-dto';
 
 export const taskRepository = {
+  // subtask service에 사용
+  async findByTaskId(taskId: number) {
+    return await db.tasks.findUnique({
+      where: { id: taskId },
+    });
+  },
+
   async findProjectById(projectId: number) {
     return await db.projects.findUnique({
       where: { id: projectId },

--- a/src/routes/index-route.ts
+++ b/src/routes/index-route.ts
@@ -3,11 +3,14 @@ import memberRouter from './member-route';
 import authRouter from './auth-route';
 import userRouter from './user-route';
 import taskRouter from './task-route';
+import subtaskRouter from './subtask-route';
+
 const router = Router();
 
 router.use('/', memberRouter);
 router.use('/auth', authRouter);
 router.use('/users', userRouter);
 router.use('/', taskRouter);
+router.use('/subtasks', subtaskRouter);
 
 export default router;

--- a/src/routes/subtask-route.ts
+++ b/src/routes/subtask-route.ts
@@ -1,12 +1,19 @@
 import express from 'express';
-import { updateSubtask, deleteSubtask } from '../controllers/subtask-controller';
-
+import { updateSubtask, deleteSubtask, getDetail } from '../controllers/subtask-controller';
+import passport from '../utils/passport/index';
 const router = express.Router();
 
-// 하위 할 일 세부조회는 frontend에 없음, 하위 할 일 생성은 taskRoute에서 합칠 예정
+router.get('/:subtaskId', passport.authenticate('access-token', { session: false }), getDetail);
 
-// router.get('/:subtaskId', getDetail);
-router.patch('/:subtaskId', updateSubtask);
-router.delete('/:subtaskId', deleteSubtask);
+router.patch(
+  '/:subtaskId',
+  passport.authenticate('access-token', { session: false }),
+  updateSubtask
+);
+router.delete(
+  '/:subtaskId',
+  passport.authenticate('access-token', { session: false }),
+  deleteSubtask
+);
 
 export default router;

--- a/src/routes/task-route.ts
+++ b/src/routes/task-route.ts
@@ -8,6 +8,7 @@ import {
   deleteTaskController,
   createComment,
 } from '../controllers/task-controller';
+import { createSubtask, getListSubtasks } from '../controllers/subtask-controller';
 
 const router = Router();
 
@@ -51,5 +52,18 @@ router.delete(
   '/tasks/:taskId',
   passport.authenticate('access-token', { session: false }),
   deleteTaskController as RequestHandler
+);
+
+// subtask 생성, subtask 목록 조회 추가
+router.post(
+  '/tasks/:taskId/subtasks',
+  passport.authenticate('access-token', { session: false }),
+  createSubtask
+);
+
+router.get(
+  '/tasks/:taskId/subtasks',
+  passport.authenticate('access-token', { session: false }),
+  getListSubtasks
 );
 export default router;

--- a/src/types/subtask-type.ts
+++ b/src/types/subtask-type.ts
@@ -1,8 +1,8 @@
-export type UpdatedSubtask = {
+export type UpdateSubtask = {
   title: string;
 };
 
-export type CreatedSubtask = {
+export type CreateSubtask = {
   title: string;
 };
 


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
#### 1. app.ts 에 등록된 subtask router를 index-route에 옮겼습니다.
#### 2. subtask 파일을 수정하여 일관된 에러처리, api명세서에는 적혀있는 subtask 상세조회 코드를 구현해놨습니다
#### 3. task-repository에 FindByTaskId 함수를 만들어 subtask-service 검증에 사용했습니다.
#### 4. task-route에 subtask 생성, 목록 조회 route를 추가했습니다. 
#### 5. passport 인증 기능을 route에 추가해서 테스트했습니다.

## ❔ 이유
<!-- 어떤 수정 사항 또는 추가 사항을 작업하게 된 이유를 작성합니다. -->
#### 3. 프론트엔드에 구현되지 않은 상세조회 코드를 구현한 이유는 개인적으로 주석처리된게 깔끔하지 않았고 api 명세서엔 적혀있는 기능이었기 때문

## 💬 리뷰어에게
<!-- 리뷰어에게 요청사항이나 참고할 점을 작성합니다. -->
#### index-route 엔드포인트를 통일하는게 좋을 것 같습니다. 