### PR TITLE
fix:유저 인증기능 프론트엔드 호환 설정

### DIFF
--- a/src/routes/user-route.ts
+++ b/src/routes/user-route.ts
@@ -1,6 +1,6 @@
 // src/routes/user-route.ts
 import express from 'express';
-import passport from 'passport';
+import passport from '../utils/passport/index';
 import { body } from 'express-validator';
 import { validateRequest } from '../middlewares/validation';
 import {

--- a/src/utils/passport/jwtStrategy.ts
+++ b/src/utils/passport/jwtStrategy.ts
@@ -7,14 +7,26 @@ import AuthRepository from '../../repositories/auth-repositorie';
 const authRepository = new AuthRepository();
 
 const accessTokenOptions = {
-  jwtFromRequest: (req: express.Request) =>
-    req.cookies[process.env.ACCESS_TOKEN_COOKIE_NAME as string],
+  jwtFromRequest: (req: express.Request) => {
+    //헤더에 토큰이 있는경우
+    if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
+      return req.headers.authorization.split(' ')[1];
+    }
+    //헤더에 토큰이 없고 쿠키에 토큰이 있는경우
+    return req.cookies[process.env.ACCESS_TOKEN_COOKIE_NAME as string];
+  },
   secretOrKey: process.env.JWT_ACCESS_TOKEN_SECRET as string,
 };
 
 const refreshTokenOptions = {
-  jwtFromRequest: (req: express.Request) =>
-    req.cookies[process.env.REFRESH_TOKEN_COOKIE_NAME as string],
+  jwtFromRequest: (req: express.Request) => {
+    //헤더에 토큰이 있는경우
+    if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
+      return req.headers.authorization.split(' ')[1];
+    }
+    //헤더에 토큰이 없고 쿠키에 토큰이 있는경우
+    return req.cookies[process.env.REFRESH_TOKEN_COOKIE_NAME as string];
+  },
   secretOrKey: process.env.JWT_REFRESH_TOKEN_SECRET as string,
 };
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -7,7 +7,11 @@ export function generateTokens(userId: number) {
   const refreshToken = jwt.sign({ sub: userId }, process.env.JWT_REFRESH_TOKEN_SECRET as string, {
     expiresIn: '7d',
   });
-  return { accessToken, refreshToken };
+
+  return {
+    accessToken,
+    refreshToken,
+  };
 }
 
 export function verifyRefreshToken(token: string): jwt.JwtPayload | null | string {


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
<!-- 어떤 수정 사항 또는 추가 사항이 있는지 기입합니다. -->
- jwt전략 파일을 프론트엔드와 호환되도록 수정했습니다.
- 유저 라우트에서 패스포트의 경로설정오류를 발견하여 수정했습니다.
<!-- 어떤 수정 사항 또는 추가 사항을 작업하게 된 이유를 작성합니다. -->
## 이유
- 인증 기능에서는 쿠키에 엑세스 토큰만을 읽고 있습니다.
- 프론트엔드에서 요청시 제공하는 헤더를 읽지 못하는 오류가 있습니다.
- 해당 오류를 해결하기 위해 헤더에 인증 요청을 감지하여 헤더를 읽어오는 코드를 추가합니다.
