### PR TITLE
Feat: swagger 문서화작업, json 파일로 각 라우트 분리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.0",
         "validator": "^13.15.15"
       },
@@ -34,6 +36,8 @@
         "@types/node": "^24.1.0",
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/passport-jwt": "^4.0.1",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/validator": "^13.15.2",
         "eslint": "^9.31.0",
         "eslint-config-prettier": "^10.1.8",
@@ -48,6 +52,50 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -311,6 +359,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -444,6 +498,13 @@
         "@prisma/debug": "6.12.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -566,7 +627,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -712,6 +772,24 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/validator": {
@@ -1115,14 +1193,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64url": {
@@ -1185,7 +1261,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1248,6 +1323,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1398,7 +1479,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -1535,6 +1615,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -1865,7 +1957,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2105,6 +2196,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2177,6 +2274,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2355,6 +2473,17 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2456,7 +2585,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2660,6 +2788,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2670,6 +2805,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -2701,6 +2843,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -2874,7 +3022,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3051,6 +3198,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3199,6 +3353,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -3825,6 +3988,80 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.0.tgz",
+      "integrity": "sha512-tS6LRyBhY6yAqxrfsA9IYpGWPUJOri6sclySa7TdC7XQfGLvTwDY531KLgfQwHEtQsn+sT4JlUspbeQDBVGWig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -4193,6 +4430,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@types/node": "^24.1.0",
     "@types/passport-google-oauth20": "^2.0.16",
     "@types/passport-jwt": "^4.0.1",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/validator": "^13.15.2",
     "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.8",
@@ -67,6 +69,8 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
     "validator": "^13.15.15"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,25 +3,10 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import routes from './routes/index-route';
 import passport from 'passport';
-import swaggerJsdoc from 'swagger-jsdoc';
-import swaggerUi from 'swagger-ui-express';
-
+import { useSwagger } from './config/swagger';
 import { errorHandler } from './middlewares/error-handler';
 
 const app = express();
-
-const options = {
-  definition: {
-    openapi: '3.0.0',
-    info: {
-      title: 'API 문서',
-      version: '1.0.0',
-    },
-  },
-  apis: ['./src/routes/*.ts'], // 타입스크립트 경로
-};
-
-const swaggerSpec = swaggerJsdoc(options);
 
 // 미들웨어 설정
 app.use(
@@ -38,9 +23,8 @@ app.use(passport.initialize());
 // 라우터 등록
 app.use('/', routes);
 
-// ✅ Swagger 문서 등록
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-
+// 스웨거 사용
+useSwagger(app);
 
 // 에러 미들웨어 등록
 app.use(errorHandler);

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,9 +3,25 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import routes from './routes/index-route';
 import passport from 'passport';
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
 import { errorHandler } from './middlewares/error-handler';
 
 const app = express();
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'API 문서',
+      version: '1.0.0',
+    },
+  },
+  apis: ['./src/routes/*.ts'], // 타입스크립트 경로
+};
+
+const swaggerSpec = swaggerJsdoc(options);
 
 // 미들웨어 설정
 app.use(
@@ -21,6 +37,10 @@ app.use(passport.initialize());
 
 // 라우터 등록
 app.use('/', routes);
+
+// ✅ Swagger 문서 등록
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
 
 // 에러 미들웨어 등록
 app.use(errorHandler);

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,0 +1,65 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+import { Express } from 'express';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Moonshot',
+      version: '1.0.0',
+    },
+    components: {
+      securitySchemes: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'access-token': {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        subtaskUpdateOrCreateRequest: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', example: '변경된 제목' },
+          },
+          required: ['title'],
+        },
+        subtaskResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            title: { type: 'string', example: '하위 할 일 제목' },
+            taskId: { type: 'integer', example: 1 },
+            status: { type: 'string', example: 'todo' },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-08-01T12:34:56Z',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-08-02T08:00:00Z',
+            },
+          },
+        },
+      },
+    },
+    security: [
+      {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'access-token': [],
+      },
+    ],
+  },
+  apis: ['./src/routes/*.ts'],
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+
+// ✅ Swagger 문서 등록
+export const useSwagger = (app: Express) => {
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+};

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -2,6 +2,14 @@ import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
 import { Express } from 'express';
 
+// import path
+import subtaskPaths from '../swagger/paths/subtask-path.json';
+import taskPaths from '../swagger/paths/task-path.json';
+import memberPaths from '../swagger/paths/member-path.json';
+import userPaths from '../swagger/paths/user-path.json';
+import projectPaths from '../swagger/paths/project-path.json';
+import authPaths from '../swagger/paths/auth-path.json';
+
 const options = {
   definition: {
     openapi: '3.0.0',
@@ -19,10 +27,349 @@ const options = {
         },
       },
       schemas: {
+        // auth req, res 형식
+        authRegisterRequest: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', format: 'email', example: 'testuser@example.com' },
+            password: { type: 'string', example: 'testpassword' },
+            name: { type: 'string', example: 'testuser' },
+            profileImage: {
+              type: ['string', 'null'],
+              format: 'uri',
+              nullable: true,
+              example: 'https://example.com/files/image.png',
+            },
+          },
+          required: ['email', 'password', 'name'],
+        },
+        authRegisterResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            email: { type: 'string', format: 'email', example: 'testuser@example.com' },
+            name: { type: 'string', example: 'testuser' },
+            profileImage: {
+              type: 'string',
+              format: 'uri',
+              example: 'https://example.com/files/image.png',
+            },
+            createdAt: { type: 'string', format: 'date-time', example: '2025-04-15T06:57:14.057Z' },
+            updatedAt: { type: 'string', format: 'date-time', example: '2025-04-15T06:57:14.057Z' },
+          },
+        },
+        loginRequest: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', example: 'user@example.com' },
+            password: { type: 'string', example: 'password123' },
+          },
+          required: ['email', 'password'],
+        },
+        loginOrRefreshResponse: {
+          type: 'object',
+          properties: {
+            accessToken: { type: 'string', example: 'eyJhbGciOiJIUzI1...' },
+            refreshToken: { type: 'string', example: 'dGhpc0lzUmVmcmVzaFRva2Vu...' },
+          },
+          required: ['accessToken', 'refreshToken'],
+        },
+
+        // project req, res 형식
+        projectCreateOrUpdateRequest: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', example: '생성, 수정된 프로젝트 1 이름 ' },
+            description: { type: 'string', example: '생성, 수정된 프로젝트 1 설명' },
+          },
+          required: ['name'],
+        },
+        projectResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            name: { type: 'string', example: '프로젝트 1' },
+            description: { type: 'string', example: '프로젝트 1 설명' },
+            memberCount: { type: 'integer', example: 1 },
+            todoCount: { type: 'integer', example: 0 },
+            inProgressCount: { type: 'integer', example: 0 },
+            doneCount: { type: 'integer', example: 0 },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-08-04T10:00:00Z',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-08-04T10:00:00Z',
+            },
+          },
+          required: ['id', 'name', 'description', 'createdAt', 'updatedAt']
+        },
+
+        // user req, res 형식
+
+        userUpdateRequest: {
+          type: 'object',
+          properties: {
+            email: { type: 'string', example: 'user@example.com' },
+            name: { type: 'string', example: '홍길동' },
+            currentPassword: { type: 'string', example: 'currentPassword123' },
+            newPassword: { type: 'string', example: 'newPassword456' },
+            profileImage: {
+              type: ['string', 'null'],
+              example: 'https://example.com/files/profile.jpg',
+              nullable: true,
+            },
+          },
+          required: ['email', 'name', 'currentPassword'],
+        },
+        userResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            email: { type: 'string', example: 'testuser@example.com' },
+            name: { type: 'string', example: 'testuser' },
+            profileImage: {
+              type: 'string',
+              example: 'https://example.com/files/image.png',
+            },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-04-15T06:57:14.057Z',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-04-15T06:57:14.057Z',
+            },
+          },
+        },
+        userProjectListResponse: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer', example: 1 },
+                  name: { type: 'string', example: '프로젝트 1' },
+                  description: { type: 'string', example: '프로젝트 1 설명' },
+                  memberCount: { type: 'integer', example: 5 },
+                  todoCount: { type: 'integer', example: 12 },
+                  inProgressCount: { type: 'integer', example: 7 },
+                  doneCount: { type: 'integer', example: 3 },
+                  createdAt: {
+                    type: 'string',
+                    format: 'date-time',
+                    example: '2025-04-15T06:57:14.057Z',
+                  },
+                  updatedAt: {
+                    type: 'string',
+                    format: 'date-time',
+                    example: '2025-04-15T06:57:14.057Z',
+                  },
+                },
+              },
+            },
+            total: { type: 'integer', example: 3 },
+          },
+          required: ['data', 'total'],
+        },
+        memberResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            name: { type: 'string', example: '홍길동' },
+            email: { type: 'string', example: 'hong@example.com' },
+            profileImage: {
+              type: 'string',
+              example: 'https://cdn.example.com/images/profile.png',
+            },
+            taskCount: { type: 'integer', example: 5 },
+            status: {
+              type: 'string',
+              enum: ['pending', 'accepted', 'rejected'],
+              example: 'accepted',
+            },
+            invitationId: { type: 'integer', example: 101 },
+          },
+        },
+        memberListResponse: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/memberResponse',
+              },
+            },
+            total: {
+              type: 'integer',
+              example: 3,
+            },
+          },
+        },
+        commentCreateOrUpdateRequest: {
+          type: 'object',
+          properties: {
+            content: { type: 'string', example: '생성된 댓글 또는 수정된 댓글' },
+          },
+          required: ['content'],
+        },
+        commentResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            content: { type: 'string', example: '댓글 내용입니다.' },
+            taskId: { type: 'integer', example: 10 },
+            author: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer', example: 5 },
+                name: { type: 'string', example: '홍길동' },
+                email: { type: 'string', example: 'hong@example.com' },
+                profileImage: {
+                  type: 'string',
+                  example: 'https://cdn.example.com/profiles/hong.png',
+                },
+              },
+            },
+            createdAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-08-01T09:00:00Z',
+            },
+            updatedAt: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-08-01T12:00:00Z',
+            },
+          },
+        },
+        commentListResponse: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/commentResponse',
+              },
+            },
+            total: {
+              type: 'integer',
+              example: 42,
+            },
+          },
+        },
+        taskCreateRequest: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', example: '새로운 작업 제목' },
+            startYear: { type: 'integer', example: 2025 },
+            startMonth: { type: 'integer', example: 8 },
+            startDay: { type: 'integer', example: 1 },
+            endYear: { type: 'integer', example: 2025 },
+            endMonth: { type: 'integer', example: 8 },
+            endDay: { type: 'integer', example: 15 },
+            status: {
+              type: 'string',
+              enum: ['todo', 'in_progress', 'done'],
+              example: 'todo',
+            },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+            attachments: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+          },
+          required: [
+            'title',
+            'startYear',
+            'startMonth',
+            'startDay',
+            'endYear',
+            'endMonth',
+            'endDay',
+            'status',
+          ],
+        },
+        taskListResponse: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/taskResponse',
+              },
+            },
+            total: { type: 'integer', example: 42 },
+          },
+        },
+        taskResponse: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            projectId: { type: 'integer', example: 10 },
+            title: { type: 'string', example: '기획안 작성' },
+            startYear: { type: 'integer', example: 2025 },
+            startMonth: { type: 'integer', example: 8 },
+            startDay: { type: 'integer', example: 1 },
+            endYear: { type: 'integer', example: 2025 },
+            endMonth: { type: 'integer', example: 8 },
+            endDay: { type: 'integer', example: 15 },
+            status: {
+              type: 'string',
+              enum: ['todo', 'in_progress', 'done'],
+              example: 'in_progress',
+            },
+            assignee: {
+              type: ['object', 'null'],
+              nullable: true,
+              properties: {
+                id: { type: 'integer', example: 5 },
+                name: { type: 'string', example: '홍길동' },
+                email: { type: 'string', example: 'hong@example.com' },
+                profileImage: {
+                  type: 'string',
+                  example: 'https://cdn.example.com/profiles/hong.png',
+                },
+              },
+            },
+            tags: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer', example: 1 },
+                  name: { type: 'string', example: '기획' },
+                },
+              },
+            },
+            attachments: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer', example: 2 },
+                  url: { type: 'string', example: 'https://cdn.example.com/files/doc.pdf' },
+                },
+              },
+            },
+            createdAt: { type: 'string', format: 'date-time', example: '2025-08-01T09:00:00Z' },
+            updatedAt: { type: 'string', format: 'date-time', example: '2025-08-01T12:00:00Z' },
+          },
+        },
         subtaskUpdateOrCreateRequest: {
           type: 'object',
           properties: {
-            title: { type: 'string', example: '변경된 제목' },
+            title: { type: 'string', example: '서브 작업 제목' },
           },
           required: ['title'],
         },
@@ -30,19 +377,11 @@ const options = {
           type: 'object',
           properties: {
             id: { type: 'integer', example: 1 },
-            title: { type: 'string', example: '하위 할 일 제목' },
+            title: { type: 'string', example: '하위 작업 제목' },
             taskId: { type: 'integer', example: 1 },
             status: { type: 'string', example: 'todo' },
-            createdAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2025-08-01T12:34:56Z',
-            },
-            updatedAt: {
-              type: 'string',
-              format: 'date-time',
-              example: '2025-08-02T08:00:00Z',
-            },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
           },
         },
       },
@@ -53,13 +392,20 @@ const options = {
         'access-token': [],
       },
     ],
+    paths: {
+      ...authPaths,
+      ...userPaths,
+      ...projectPaths,
+      ...taskPaths,
+      ...memberPaths,
+      ...subtaskPaths,
+    },
   },
   apis: ['./src/routes/*.ts'],
 };
 
 const swaggerSpec = swaggerJsdoc(options);
 
-// ✅ Swagger 문서 등록
 export const useSwagger = (app: Express) => {
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 };

--- a/src/routes/subtask-route.ts
+++ b/src/routes/subtask-route.ts
@@ -4,112 +4,13 @@ import passport from '../utils/passport/index';
 
 const router = express.Router();
 
-/**
- * @swagger
- * /subtasks/{subtaskId}:
- *   get:
- *     summary: 하위 할 일 조회
- *     tags:
- *       - Subtasks
- *     parameters:
- *       - in: path
- *         name: subtaskId
- *         required: true
- *         schema:
- *           type: string
- *         description: 조회할 하위 할 일 ID
- *     security:
- *       - access-token: []
- *     responses:
- *       '200':
- *         description: 하위 할 일 상세 정보 반환
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/subtaskResponse'
- *       '400':
- *         description: 잘못된 요청 형식
- *       '401':
- *         description: 로그인이 필요합니다.
- *       '403':
- *         description: 프로젝트 멤버가 아닙니다.
- *       '404':
- *         description: 해당 하위 할 일을 찾을 수 없습니다.
- */
-
 router.get('/:subtaskId', passport.authenticate('access-token', { session: false }), getDetail);
-
-/**
- * @swagger
- * /subtasks/{subtaskId}:
- *   patch:
- *     summary: 하위 할 일 수정
- *     tags:
- *       - Subtasks
- *     parameters:
- *       - in: path
- *         name: subtaskId
- *         required: true
- *         schema:
- *           type: string
- *         description: 조회할 하위 할 일 ID
- *     security:
- *       - access-token: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/subtaskUpdateOrCreateRequest'
- *     responses:
- *       '200':
- *         description: 하위 할 일 수정
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/subtaskResponse'
- *       '400':
- *         description: 잘못된 요청 형식
- *       '401':
- *         description: 로그인이 필요합니다.
- *       '403':
- *         description: 프로젝트 멤버가 아닙니다.
- */
 
 router.patch(
   '/:subtaskId',
   passport.authenticate('access-token', { session: false }),
   updateSubtask
 );
-
-/**
- * @swagger
- * /subtasks/{subtaskId}:
- *   delete:
- *     summary: 특정 서브태스크 삭제
- *     tags:
- *       - Subtasks
- *     parameters:
- *       - in: path
- *         name: subtaskId
- *         required: true
- *         schema:
- *           type: string
- *         description: 삭제할 서브태스크 ID
- *     security:
- *       - access-token: []
- *     responses:
- *       '204':
- *         description: 삭제 성공 (응답 본문 없음)
- *       '400':
- *         description: 잘못된 요청 형식
- *       '401':
- *         description: 로그인이 필요합니다
- *       '403':
- *         description: 프로젝트 멤버가 아닙니다
- *       '404':
- *         description: (없음)
- */
 
 router.delete(
   '/:subtaskId',

--- a/src/routes/subtask-route.ts
+++ b/src/routes/subtask-route.ts
@@ -1,15 +1,112 @@
 import express from 'express';
 import { updateSubtask, deleteSubtask, getDetail } from '../controllers/subtask-controller';
 import passport from '../utils/passport/index';
+
 const router = express.Router();
 
+/**
+ * @swagger
+ * /subtasks/{subtaskId}:
+ *   get:
+ *     summary: 특정 서브태스크 상세 조회
+ *     tags:
+ *       - Subtasks
+ *     parameters:
+ *       - in: path
+ *         name: subtaskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 조회할 서브태스크 ID
+ *     security:
+ *       - access-token: []
+ *     responses:
+ *       200:
+ *         description: 서브태스크 상세 정보 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   example: "123"
+ *                 title:
+ *                   type: string
+ *                   example: "서브태스크 제목"
+ *                 completed:
+ *                   type: boolean
+ *                   example: false
+ *       401:
+ *         description: 인증 실패
+ */
 router.get('/:subtaskId', passport.authenticate('access-token', { session: false }), getDetail);
 
+/**
+ * @swagger
+ * /subtasks/{subtaskId}:
+ *   patch:
+ *     summary: 특정 서브태스크 수정
+ *     tags:
+ *       - Subtasks
+ *     parameters:
+ *       - in: path
+ *         name: subtaskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 수정할 서브태스크 ID
+ *     security:
+ *       - access-token: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: "변경된 제목"
+ *               completed:
+ *                 type: boolean
+ *                 example: true
+ *     responses:
+ *       200:
+ *         description: 수정 성공
+ *       400:
+ *         description: 잘못된 요청
+ *       401:
+ *         description: 인증 실패
+ */
 router.patch(
   '/:subtaskId',
   passport.authenticate('access-token', { session: false }),
   updateSubtask
 );
+
+/**
+ * @swagger
+ * /subtasks/{subtaskId}:
+ *   delete:
+ *     summary: 특정 서브태스크 삭제
+ *     tags:
+ *       - Subtasks
+ *     parameters:
+ *       - in: path
+ *         name: subtaskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 삭제할 서브태스크 ID
+ *     security:
+ *       - access-token: []
+ *     responses:
+ *       204:
+ *         description: 삭제 성공 (응답 본문 없음)
+ *       401:
+ *         description: 인증 실패
+ */
 router.delete(
   '/:subtaskId',
   passport.authenticate('access-token', { session: false }),

--- a/src/routes/subtask-route.ts
+++ b/src/routes/subtask-route.ts
@@ -8,7 +8,7 @@ const router = express.Router();
  * @swagger
  * /subtasks/{subtaskId}:
  *   get:
- *     summary: 특정 서브태스크 상세 조회
+ *     summary: 하위 할 일 조회
  *     tags:
  *       - Subtasks
  *     parameters:
@@ -17,36 +17,33 @@ const router = express.Router();
  *         required: true
  *         schema:
  *           type: string
- *         description: 조회할 서브태스크 ID
+ *         description: 조회할 하위 할 일 ID
  *     security:
  *       - access-token: []
  *     responses:
- *       200:
- *         description: 서브태스크 상세 정보 반환
+ *       '200':
+ *         description: 하위 할 일 상세 정보 반환
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 id:
- *                   type: string
- *                   example: "123"
- *                 title:
- *                   type: string
- *                   example: "서브태스크 제목"
- *                 completed:
- *                   type: boolean
- *                   example: false
- *       401:
- *         description: 인증 실패
+ *               $ref: '#/components/schemas/subtaskResponse'
+ *       '400':
+ *         description: 잘못된 요청 형식
+ *       '401':
+ *         description: 로그인이 필요합니다.
+ *       '403':
+ *         description: 프로젝트 멤버가 아닙니다.
+ *       '404':
+ *         description: 해당 하위 할 일을 찾을 수 없습니다.
  */
+
 router.get('/:subtaskId', passport.authenticate('access-token', { session: false }), getDetail);
 
 /**
  * @swagger
  * /subtasks/{subtaskId}:
  *   patch:
- *     summary: 특정 서브태스크 수정
+ *     summary: 하위 할 일 수정
  *     tags:
  *       - Subtasks
  *     parameters:
@@ -55,7 +52,7 @@ router.get('/:subtaskId', passport.authenticate('access-token', { session: false
  *         required: true
  *         schema:
  *           type: string
- *         description: 수정할 서브태스크 ID
+ *         description: 조회할 하위 할 일 ID
  *     security:
  *       - access-token: []
  *     requestBody:
@@ -63,22 +60,22 @@ router.get('/:subtaskId', passport.authenticate('access-token', { session: false
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               title:
- *                 type: string
- *                 example: "변경된 제목"
- *               completed:
- *                 type: boolean
- *                 example: true
+ *             $ref: '#/components/schemas/subtaskUpdateOrCreateRequest'
  *     responses:
- *       200:
- *         description: 수정 성공
- *       400:
- *         description: 잘못된 요청
- *       401:
- *         description: 인증 실패
+ *       '200':
+ *         description: 하위 할 일 수정
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/subtaskResponse'
+ *       '400':
+ *         description: 잘못된 요청 형식
+ *       '401':
+ *         description: 로그인이 필요합니다.
+ *       '403':
+ *         description: 프로젝트 멤버가 아닙니다.
  */
+
 router.patch(
   '/:subtaskId',
   passport.authenticate('access-token', { session: false }),
@@ -102,11 +99,18 @@ router.patch(
  *     security:
  *       - access-token: []
  *     responses:
- *       204:
+ *       '204':
  *         description: 삭제 성공 (응답 본문 없음)
- *       401:
- *         description: 인증 실패
+ *       '400':
+ *         description: 잘못된 요청 형식
+ *       '401':
+ *         description: 로그인이 필요합니다
+ *       '403':
+ *         description: 프로젝트 멤버가 아닙니다
+ *       '404':
+ *         description: (없음)
  */
+
 router.delete(
   '/:subtaskId',
   passport.authenticate('access-token', { session: false }),

--- a/src/routes/task-route.ts
+++ b/src/routes/task-route.ts
@@ -54,84 +54,18 @@ router.delete(
   deleteTaskController as RequestHandler
 );
 
-// subtask 생성, subtask 목록 조회 추가
-/**
- * @swagger
- * /tasks/{taskId}/subtasks:
- *   post:
- *     summary: 하위 할 일 생성
- *     tags:
- *       - Subtasks
- *     parameters:
- *       - in: path
- *         name: taskId
- *         required: true
- *         schema:
- *           type: string
- *         description: 하위 할 일이 속한 할 일 ID
- *     security:
- *       - access-token: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/subtaskUpdateOrCreateRequest'
- *     responses:
- *       '201':
- *         description: 하위 할 일 생성 성공
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/subtaskResponse'
- *       '400':
- *         description: 잘못된 요청 형식
- *       '401':
- *         description: 로그인이 필요합니다
- *       '403':
- *         description: 프로젝트 멤버가 아닙니다
- */
-
+// 하위 할 일 생성
 router.post(
   '/tasks/:taskId/subtasks',
   passport.authenticate('access-token', { session: false }),
   createSubtask
 );
 
-/**
- * @swagger
- * /tasks/{taskId}/subtasks:
- *   get:
- *     summary: 하위 할 일 목록 조회
- *     tags:
- *       - Subtasks
- *     parameters:
- *       - in: path
- *         name: taskId
- *         required: true
- *         schema:
- *           type: string
- *         description: 하위 할 일 목록을 조회할 할 일 ID
- *     security:
- *       - access-token: []
- *     responses:
- *       '200':
- *         description: 서브태스크 목록 반환
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/subtaskResponse'
- *       '401':
- *         description: 인증 실패
- *       '403':
- *         description: 권한 없음
- */
-
+// 하위 할 일 목록 조회
 router.get(
   '/tasks/:taskId/subtasks',
   passport.authenticate('access-token', { session: false }),
   getListSubtasks
 );
+
 export default router;

--- a/src/routes/task-route.ts
+++ b/src/routes/task-route.ts
@@ -55,11 +55,79 @@ router.delete(
 );
 
 // subtask 생성, subtask 목록 조회 추가
+/**
+ * @swagger
+ * /tasks/{taskId}/subtasks:
+ *   post:
+ *     summary: 하위 할 일 생성
+ *     tags:
+ *       - Subtasks
+ *     parameters:
+ *       - in: path
+ *         name: taskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 하위 할 일이 속한 할 일 ID
+ *     security:
+ *       - access-token: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/subtaskUpdateOrCreateRequest'
+ *     responses:
+ *       '201':
+ *         description: 하위 할 일 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/subtaskResponse'
+ *       '400':
+ *         description: 잘못된 요청 형식
+ *       '401':
+ *         description: 로그인이 필요합니다
+ *       '403':
+ *         description: 프로젝트 멤버가 아닙니다
+ */
+
 router.post(
   '/tasks/:taskId/subtasks',
   passport.authenticate('access-token', { session: false }),
   createSubtask
 );
+
+/**
+ * @swagger
+ * /tasks/{taskId}/subtasks:
+ *   get:
+ *     summary: 하위 할 일 목록 조회
+ *     tags:
+ *       - Subtasks
+ *     parameters:
+ *       - in: path
+ *         name: taskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 하위 할 일 목록을 조회할 할 일 ID
+ *     security:
+ *       - access-token: []
+ *     responses:
+ *       '200':
+ *         description: 서브태스크 목록 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/subtaskResponse'
+ *       '401':
+ *         description: 인증 실패
+ *       '403':
+ *         description: 권한 없음
+ */
 
 router.get(
   '/tasks/:taskId/subtasks',

--- a/src/swagger/paths/auth-path.json
+++ b/src/swagger/paths/auth-path.json
@@ -1,0 +1,140 @@
+{
+  "/auth/register": {
+    "post": {
+      "summary": "회원 가입",
+      "tags": [
+        "Auth"
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/authRegisterRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "201": {
+          "description": "회원 가입 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/authRegisterResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 데이터 또는 이미 가입한 이메일입니다."
+        }
+      }
+    }
+  },
+  "/auth/login": {
+    "post": {
+      "summary": "로그인",
+      "tags": [
+        "Auth"
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/loginRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "로그인 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/loginOrRefreshResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청입니다"
+        },
+        "404": {
+          "description": "존재하지 않거나 비밀번호가 일치하지 않습니다"
+        }
+      }
+    }
+  },
+  "/auth/refresh": {
+    "post": {
+      "summary": "토큰 갱신",
+      "tags": [
+        "Auth"
+      ],
+      "responses": {
+        "200": {
+          "description": "토큰 갱신 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/loginOrRefreshResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청입니다"
+        },
+        "401": {
+          "description": "토큰 만료"
+        }
+      }
+    }
+  },
+   "/auth/google": {
+    "get": {
+      "summary": "구글 로그인 리다이렉트",
+      "tags": ["Auth"],
+      "responses": {
+        "307": {
+          "description": "Google 로그인 사이트로 리디렉션",
+          "headers": {
+            "Location": {
+              "description": "리디렉션할 Google 로그인 URL (redirect_uri 포함)",
+              "schema": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "/auth/google/callback": {
+    "get": {
+      "summary": "Google OAuth 콜백 - 인증 성공 시 프론트엔드로 리다이렉트",
+      "tags": ["Auth"],
+      "responses": {
+        "307": {
+          "description": "인증 성공 후 프론트엔드 사이트로 리다이렉트",
+          "headers": {
+            "Location": {
+              "description": "리다이렉션할 프론트엔드 URL",
+              "schema": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "인증 실패"
+        }
+      }
+    }
+  }
+}

--- a/src/swagger/paths/member-path.json
+++ b/src/swagger/paths/member-path.json
@@ -1,0 +1,243 @@
+{
+  "/projects/{projectId}/users": {
+    "get": {
+      "summary": "프로젝트 멤버 목록 조회",
+      "tags": [
+        "Members"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "projectId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "멤버 목록을 조회할 프로젝트 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "프로젝트 멤버 목록 반환",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/memberListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        }
+      }
+    }
+  },
+  "/projects/{projectId}/users/{userId}": {
+    "delete": {
+      "summary": "프로젝트에서 유저 제외",
+      "tags": [
+        "Members"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "projectId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "유저를 제외할 대상 프로젝트 ID"
+        },
+        {
+          "in": "path",
+          "name": "userId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "제외할 사용자 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "204": {
+          "description": "유저 제외 성공 (응답 본문 없음)"
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 관리자가 아닙니다"
+        },
+        "404": {
+          "description": "프로젝트 또는 유저를 찾을 수 없음"
+        }
+      }
+    }
+  },
+  "/projects/{projectId}/invitations": {
+    "post": {
+      "summary": "프로젝트에 멤버 초대",
+      "tags": [
+        "Members"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "projectId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "멤버를 초대할 프로젝트 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "example": "invitee@example.com",
+                  "description": "초대할 멤버의 이메일"
+                }
+              },
+              "required": [
+                "email"
+              ]
+            }
+          }
+        }
+      },
+      "responses": {
+        "201": {
+          "description": "멤버 초대 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "invitationId": {
+                    "type": "string",
+                    "example": "abc123xyz"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 관리자가 아닙니다"
+        }
+      }
+    }
+  },
+  "/invitations/{invitationId}/accept": {
+    "post": {
+      "summary": "초대 수락",
+      "tags": [
+        "Members"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "invitationId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "수락할 초대 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+         "description": "초대 수락 성공 (응답 본문 없음)"
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "404": {
+          "description": "초대를 찾을 수 없음"
+        }
+      }
+    }
+  },
+  
+  "/invitations/{invitationId}": {
+    "delete": {
+      "summary": "초대 삭제",
+      "tags": ["Members"],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "invitationId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "삭제할 초대 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "204": {
+          "description": "초대 삭제 성공 (응답 본문 없음)"
+        },
+        "400":{
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다."
+        },
+        "403": {
+          "description": "권한이 없습니다."
+        },
+        "404": {
+          "description": "초대를 찾을 수 없음"
+        }
+      }
+    }
+  }
+}

--- a/src/swagger/paths/project-path.json
+++ b/src/swagger/paths/project-path.json
@@ -1,0 +1,180 @@
+{
+  "/projects": {
+    "post": {
+      "summary": "프로젝트 생성",
+      "tags": [
+        "Projects"
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/projectCreateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "프로젝트 생성 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/projectResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 데이터 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        }
+      }
+    }
+  },
+  "/projects/{projectId}": {
+    "get": {
+      "summary": "프로젝트 조회",
+      "tags": [
+        "Projects"
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "projectId",
+          "in": "path",
+          "description": "조회할 프로젝트 ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "프로젝트 조회 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/projectResponse"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        },
+        "404": {
+          "description": "(없음)"
+        }
+      }
+    },
+    "patch": {
+      "summary": "프로젝트 수정",
+      "tags": [
+        "Projects"
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "projectId",
+          "in": "path",
+          "description": "수정할 프로젝트 ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/projectCreateOrUpdateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "프로젝트 수정 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/projectResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 데이터"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 관리자가 아닙니다"
+        }
+      }
+    },
+    "delete": {
+      "summary": "프로젝트 삭제",
+      "tags": [
+        "Projects"
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "projectId",
+          "in": "path",
+          "description": "삭제할 프로젝트 ID",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "responses": {
+        "204": {
+          "description": "프로젝트 삭제 성공 (응답 바디 없음)"
+        },
+        "400": {
+          "description": "잘못된 요청 데이터"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 관리자가 아닙니다"
+        },
+        "404": {
+          "description": "(없음)"
+        }
+      }
+    }
+  }
+}

--- a/src/swagger/paths/subtask-path.json
+++ b/src/swagger/paths/subtask-path.json
@@ -1,0 +1,94 @@
+{
+  "/subtasks/{subtaskId}": {
+    "get": {
+      "summary": "하위 할 일 조회",
+      "tags": ["Subtasks"],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "subtaskId",
+          "required": true,
+          "schema": { "type": "string" },
+          "description": "조회할 하위 할 일 ID"
+        }
+      ],
+      "security": [{ "access-token": [] }],
+      "responses": {
+        "200": {
+          "description": "하위 할 일 상세 정보 반환",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subtaskResponse"
+              }
+            }
+          }
+        },
+        "400": { "description": "잘못된 요청 형식" },
+        "401": { "description": "로그인이 필요합니다." },
+        "403": { "description": "프로젝트 멤버가 아닙니다." },
+        "404": { "description": "해당 하위 할 일을 찾을 수 없습니다." }
+      }
+    },
+    "patch": {
+      "summary": "하위 할 일 수정",
+      "tags": ["Subtasks"],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "subtaskId",
+          "required": true,
+          "schema": { "type": "string" },
+          "description": "조회할 하위 할 일 ID"
+        }
+      ],
+      "security": [{ "access-token": [] }],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/subtaskUpdateOrCreateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "하위 할 일 수정",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subtaskResponse"
+              }
+            }
+          }
+        },
+        "400": { "description": "잘못된 요청 형식" },
+        "401": { "description": "로그인이 필요합니다." },
+        "403": { "description": "프로젝트 멤버가 아닙니다." }
+      }
+    },
+    "delete": {
+      "summary": "하위 할 일 삭제",
+      "tags": ["Subtasks"],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "subtaskId",
+          "required": true,
+          "schema": { "type": "string" },
+          "description": "삭제할 하위 할 일 ID"
+        }
+      ],
+      "security": [{ "access-token": [] }],
+      "responses": {
+        "204": { "description": "삭제 성공 (응답 본문 없음)" },
+        "400": { "description": "잘못된 요청 형식" },
+        "401": { "description": "로그인이 필요합니다" },
+        "403": { "description": "프로젝트 멤버가 아닙니다" },
+        "404": { "description": "(없음)" }
+      }
+    }
+  }
+}

--- a/src/swagger/paths/task-path.json
+++ b/src/swagger/paths/task-path.json
@@ -1,0 +1,582 @@
+{
+  "/projects/{projectId}/tasks": {
+    "post": {
+      "summary": "프로젝트에 할 일 생성",
+      "tags": [
+        "Tasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "projectId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "할 일이 생성될 프로젝트 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/taskCreateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "할 일 생성 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/taskResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        }
+      }
+    },
+    "get": {
+      "summary": "프로젝트의 할 일 목록 조회",
+      "tags": [
+        "Tasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "projectId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "할 일 목록을 가져올 프로젝트 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "할 일 목록 반환",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/taskListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        }
+      }
+    }
+  },
+  "/tasks/{taskId}": {
+    "get": {
+      "summary": "할 일 조회",
+      "tags": [
+        "Tasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "조회할 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "할 일 상세 정보 반환",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/taskResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        },
+        "404": {
+          "description": "할 일을 찾을 수 없음"
+        }
+      }
+    },
+    "patch": {
+      "summary": "할 일 수정",
+      "tags": [
+        "Tasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "수정할 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/taskUpdateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "할 일 수정 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/taskResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        },
+        "404": {
+          "description": "할 일을 찾을 수 없음"
+        }
+      }
+    },
+    "delete": {
+      "summary": "할 일 삭제",
+      "tags": [
+        "Tasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "삭제할 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "204": {
+          "description": "할 일 삭제 성공 (응답 본문 없음)"
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        },
+        "404": {
+          "description": "할 일을 찾을 수 없음"
+        }
+      }
+    }
+  },
+  "/tasks/{taskId}/comments": {
+    "post": {
+      "summary": "할 일에 댓글 추가",
+      "tags": [
+        "Comments"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "댓글을 추가할 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/commentCreateOrUpdateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "댓글 생성 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/commentResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        }
+      }
+    },
+    "get": {
+      "summary": "할 일의 댓글 목록 조회",
+      "tags": [
+        "Comments"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "댓글 목록을 조회할 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "댓글 목록 조회 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/commentListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        }
+      }
+    }
+  },
+  "/comments/{commentId}": {
+    "get": {
+      "summary": "댓글 조회",
+      "tags": [
+        "Comments"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "조회할 댓글 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "댓글 상세 정보 반환",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/commentResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        },
+        "404": {
+          "description": "댓글을 찾을 수 없습니다"
+        }
+      }
+    },
+    "patch": {
+      "summary": "댓글 수정",
+      "tags": [
+        "Comments"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "수정할 댓글 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/commentCreateOrUpdateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "댓글 수정 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/commentResponse"
+              }
+            }
+          }
+        },
+       "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "자신이 작성한 댓글만 수정할 수 있습니다"
+        },
+        "404": {
+          "description": "댓글을 찾을 수 없습니다"
+        }
+      }
+    },
+    "delete": {
+      "summary": "댓글 삭제",
+      "tags": [
+        "Comments"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "commentId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "삭제할 댓글 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "204": {
+          "description": "댓글 삭제 성공 (응답 본문 없음)"
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "자신이 작성한 댓글만 삭제할 수 있습니다"
+        },
+        "404": {
+          "description": "댓글을 찾을 수 없습니다"
+        }
+      }
+    }
+  },
+  "/tasks/{taskId}/subtasks": {
+    "post": {
+      "summary": "하위 할 일 생성",
+      "tags": [
+        "Subtasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "하위 할 일이 속한 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/subtaskUpdateOrCreateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "201": {
+          "description": "하위 할 일 생성 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/subtaskResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "403": {
+          "description": "프로젝트 멤버가 아닙니다"
+        }
+      }
+    },
+    "get": {
+      "summary": "하위 할 일 목록 조회",
+      "tags": [
+        "Subtasks"
+      ],
+      "parameters": [
+        {
+          "in": "path",
+          "name": "taskId",
+          "required": true,
+          "schema": {
+            "type": "string"
+          },
+          "description": "하위 할 일 목록을 조회할 할 일 ID"
+        }
+      ],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "서브태스크 목록 반환",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/subtaskResponse"
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "인증 실패"
+        },
+        "403": {
+          "description": "권한 없음"
+        }
+      }
+    }
+  }
+}

--- a/src/swagger/paths/user-path.json
+++ b/src/swagger/paths/user-path.json
@@ -1,0 +1,223 @@
+{
+  "/users/me": {
+    "get": {
+      "summary": "내 정보 조회",
+      "tags": ["Users"],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "내 정보 조회 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/userResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청입니다"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        },
+        "404": {
+          "description": "존재하지 않는 유저입니다"
+        }
+      }
+    },
+    "patch": {
+      "summary": "내 정보 수정",
+      "tags": ["Users"],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/userUpdateRequest"
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "정보 수정 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/userResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 데이터 형식"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        }
+      }
+    }
+  },
+  "/users/me/projects": {
+    "get": {
+      "summary": "내가 참여 중인 프로젝트 목록 조회",
+      "tags": ["Users"],
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "프로젝트 목록 조회 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/userProjectListResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "잘못된 요청입니다"
+        },
+        "401": {
+          "description": "로그인이 필요합니다"
+        }
+      }
+    }
+  },
+  "/users/me/tasks": {
+    "get": {
+      "tags": ["Users"],
+      "summary": "참여중인 모든 프로젝트의 할 일 목록 조회",
+      "description": "사용자가 참여 중인 모든 프로젝트의 할 일 목록을 조회합니다.",
+      "operationId": "getUserTasks",
+      "security": [
+        {
+          "access-token": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "from",
+          "in": "query",
+          "description": "조회 시작 날짜 (YYYY-MM-DD)",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        {
+          "name": "to",
+          "in": "query",
+          "description": "조회 종료 날짜 (YYYY-MM-DD)",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "format": "date"
+          }
+        },
+        {
+          "name": "project_id",
+          "in": "query",
+          "description": "프로젝트 ID 필터",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "status",
+          "in": "query",
+          "description": "작업 상태 필터",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "enum": ["todo", "in_progress", "done"]
+          }
+        },
+        {
+          "name": "assignee",
+          "in": "query",
+          "description": "담당자 ID 필터",
+          "required": false,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "keyword",
+          "in": "query",
+          "description": "제목 검색어",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "참여 프로젝트의 할 일 목록 조회 성공",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/taskListResponse"
+              },
+              "examples": {
+                "example-1": {
+                  "value": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "projectId": 101,
+                        "title": "기획안 작성",
+                        "startYear": 2025,
+                        "startMonth": 8,
+                        "startDay": 1,
+                        "endYear": 2025,
+                        "endMonth": 8,
+                        "endDay": 15,
+                        "status": "in_progress",
+                        "assignee": {
+                          "id": 7,
+                          "name": "홍길동",
+                          "email": "hong@example.com",
+                          "profileImage": "https://cdn.example.com/profiles/hong.png"
+                        },
+                        "tags": [
+                          { "id": 1, "name": "기획" },
+                          { "id": 2, "name": "긴급" }
+                        ],
+                        "attachments": [
+                          { "id": 10, "url": "https://cdn.example.com/files/doc1.pdf" }
+                        ],
+                        "createdAt": "2025-08-01T10:00:00Z",
+                        "updatedAt": "2025-08-03T14:30:00Z"
+                      }
+                    ],
+                    "total": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "인증 실패 또는 토큰 만료"
+        }
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,7 @@
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
     // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
<!-- 어떤 수정 사항 또는 추가 사항이 있는지 기입합니다. -->
- swagger-jsdoc, swagger-ui-express 패키지를 설치하여 swagger 문서화 작업을 했습니다.
- config 폴더 안 swagger.ts 파일을 생성해 swagger 옵션,  req, res 스키마형식을 정해주고 ref방식으로 path.json파일에 사용 했습니다.
- swagger.ts 마지막 줄 
```
export const useSwagger = (app: Express) => {
  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
};
``` 
-  app.ts 로 export 했습니다
- swagger 폴더를 생성하고 paths폴더 안에 각 api 별 path.json 파일을 생성하여 문서화 작업을 했습니다.


## ❔ 이유
<!-- 어떤 수정 사항 또는 추가 사항을 작업하게 된 이유를 작성합니다. -->
- 기존 route파일에 jsdoc 주석으로 코드를 작성하면 가독성이 떨어지고 기존 route파일이 매우 길어져 따로 .json파일로 관리하기위해

## 💬 리뷰어에게
<!-- 리뷰어에게 요청사항이나 참고할 점을 작성합니다. -->
- 대략적으로 전체적인 틀을 완성했지만 세부적인 사항에 오타가 있을 수 있어 자신이 담당한 api 확인부탁드립니다!