### PR TITLE
feat: 프로젝트 생성 시 최대 5개 제한 추가

### DIFF
--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -43,7 +43,9 @@ export const handleError = (
   message: string = errorMsg.serverError,
   status: number = statusCode.internalServerError
 ) => {
-  console.error('Error:', error);
+  if (error) {
+    console.error('Error:', error);
+  }
   const err = new Error(message) as Error & { status?: number };
   err.status = status;
   return next(err);

--- a/src/repositories/project-repository.ts
+++ b/src/repositories/project-repository.ts
@@ -4,7 +4,7 @@ import { task_status } from '@prisma/client';
 interface CreateProjectParams {
   creatorId: number;
   name: string;
-  description: string;
+  description?: string;
 }
 
 interface UpdateProjectParams {
@@ -26,10 +26,16 @@ interface GetProjectWithCounts {
   };
 }
 
+export const countProjectsByCreator = async (creatorId: number): Promise<number> => {
+  return await prisma.projects.count({
+    where: { creatorId },
+  });
+};
+
 export const createProjectWithMember = async ({
   creatorId,
   name,
-  description,
+  description = '',
 }: CreateProjectParams) => {
   return await prisma.$transaction(async (tx) => {
     const newProject = await tx.projects.create({

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -26,6 +26,18 @@ type ProjectSummary = {
 export const createProjectService = async (
   params: CreateProjectDTO
 ): Promise<ServiceResult<ProjectSummary>> => {
+  // 최대 생성 제한 체크
+  const projectCount = await projectRepository.countProjectsByCreator(params.creatorId);
+
+  if (projectCount >= 5) {
+    return {
+      error: true,
+      status: statusCode.badRequest,
+      message: errorMsg.maxProjectLimit,
+    };
+  }
+
+  // 제한 미충족 시 생성 진행
   const newProject = await projectRepository.createProjectWithMember(params);
 
   return {
@@ -128,7 +140,6 @@ export const deleteProjectService = async (
     };
   }
 
-  // 멤버 이메일 리스트 조회
   const membersEmails = await projectRepository.getProjectMembersEmails(projectId);
 
   await projectRepository.deleteProject(projectId);


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
- Error: null과 같이 불필요한 에러 메시지 출력 삭제
- 사용자가 생성할 수 있는 프로젝트 수를 최대 5개로 제한하는 로직 추가
- projects.service.ts에서 생성 전 유저의 프로젝트 개수 조회하여 예외 처리
제한 초과 시 400 에러와 함께 "프로젝트는 최대 5개까지 생성할 수 있습니다." 메시지 반환

## ❔ 이유
- 에러가 있을 때만 에러 메시지를 출력하고 null일 때는 안뜨도록 하였습니다.
- 기능 요구사항에서 빠진 부분이 있어 추가 하였습니다.

## 💬 리뷰어에게
- 실수로  upstream/dev 브랜치에 푸시되어 바로 revert 처리했습니다. 죄송합니다.
- 변경된 기능이 정상적으로 동작하는지, 프로젝트 생성 제한 메시지가 출력되는지 확인 부탁드립니다.
- 추가로 테스트 중 발견되는 이슈나 개선점이 있다면 편하게 말씀해 주세요 !