### PR TITLE
fix: 하위할일 프론트 요청 필드명 변환

### DIFF
--- a/src/services/subtask-service.ts
+++ b/src/services/subtask-service.ts
@@ -91,6 +91,12 @@ export const subtaskService = {
     const isProjectMember = await memberRepository.isProjectMember(task.projectId, userId);
     if (!isProjectMember) throw { status: statusCode.forbidden, message: errorMsg.accessDenied };
 
+    // status 를 isDone 으로 변환
+    if ('status' in data) {
+      data.isDone = data.status === 'done';
+      delete data.status;
+    }
+
     const updated = await subtaskRepository.update(subTaskId, data);
     return {
       id: updated.id,


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
<!-- 어떤 수정 사항 또는 추가 사항이 있는지 기입합니다. -->
- 하위 할일 수정 시 프론트에서 보내는 요청  status 를 백엔드  indone 로 매핑하여 처리하도록 수정했습니다
## ❔ 이유
<!-- 어떤 수정 사항 또는 추가 사항을 작업하게 된 이유를 작성합니다. -->
- 하위 할일 체크박스를 수정할 때 프론트와 백엔드간 필드명이 달라 오류가 나는 부분을 수정했습니다
## 💬 리뷰어에게
<!-- 리뷰어에게 요청사항이나 참고할 점을 작성합니다. -->