### PR TITLE
fix: 첨부파일 등록 오류 수정

### DIFF
--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -209,10 +209,7 @@ export const taskService = {
         id: tag.id,
         name: tag.tag,
       })),
-      attachments: task.taskFiles.map((file) => ({
-        id: file.id,
-        url: file.fileUrl,
-      })),
+      attachments: task.taskFiles.map((file) => file.fileUrl),
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
     };
@@ -246,8 +243,12 @@ export const taskService = {
       throw { status: statusCode.forbidden, message: errorMsg.accessDenied };
     }
 
-    const startedAt = new Date(startYear, startMonth - 1, startDay);
-    const dueDate = new Date(endYear, endMonth - 1, endDay);
+    const startedAt =
+      startYear && startMonth && startDay
+        ? new Date(startYear, startMonth - 1, startDay)
+        : undefined;
+    const dueDate =
+      endYear && endMonth && endDay ? new Date(endYear, endMonth - 1, endDay) : undefined;
 
     const updatedTask = await taskRepository.updateTask({
       taskId,
@@ -291,10 +292,7 @@ export const taskService = {
         id: tag.id,
         name: tag.tag,
       })),
-      attachments: updatedTask.taskFiles.map((file) => ({
-        id: file.id,
-        url: file.fileUrl,
-      })),
+      attachments: updatedTask.taskFiles.map((file) => file.fileUrl),
       createdAt: updatedTask.createdAt,
       updatedAt: updatedTask.updatedAt,
     };


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
<!-- 어떤 수정 사항 또는 추가 사항이 있는지 기입합니다. -->
-  할 일 페이지에서 첨부파일 업데이트 시 `startedAt`과 `dueDate`가 `undefined`여도 업데이트가 가능하도록 변경했습니다.
- 할 일 조회 및 업데이트 API의 첨부파일 응답 형식을 객체배열에서 문자열 배열로 수정했습니다.
## ❔ 이유
<!-- 어떤 수정 사항 또는 추가 사항을 작업하게 된 이유를 작성합니다. -->
- 프론트엔드에서 첨부파일만 업데이트하는 경우, startedAt, dueDate를 전달하지 않아 백엔드에서 오류가 발생했습니다. 이 문제를 해결하기 위해 해당 필드 없이도 업데이트가 가능하도록 수정했습니다.
- 프론트엔드의 응답 형식 요구사항과 백엔드에서 보내는 실제 응답 형식이 달라 문제가 있었습니다. 두 값을 맞추기 위해 백엔드 리스폰스 값을 수정했습니다.
## 💬 리뷰어에게
<!-- 리뷰어에게 요청사항이나 참고할 점을 작성합니다. -->