### PR TITLE
refactor: getMyTasks 응답에 날짜 분리 필드와 관계 데이터 포함

### DIFF
--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -97,7 +97,25 @@ class UserService {
   }
 
   async getMyTasks(userId: number, filter: TaskFilterOptions) {
-    return this.userRepository.findTasksByUser(userId, filter);
+    const tasks = await this.userRepository.findTasksByUser(userId, filter);
+
+    return tasks.map((task) => ({
+      id: task.id,
+      projectId: task.projectId,
+      title: task.title,
+      startYear: task.startedAt?.getFullYear() ?? null,
+      startMonth: task.startedAt ? task.startedAt.getMonth() + 1 : null,
+      startDay: task.startedAt?.getDate() ?? null,
+      endYear: task.dueDate?.getFullYear() ?? null,
+      endMonth: task.dueDate ? task.dueDate.getMonth() + 1 : null,
+      endDay: task.dueDate?.getDate() ?? null,
+      status: task.status,
+      assignee: task.user,
+      tags: task.taskTags.map((tag) => tag.tag),
+      attachments: task.taskFiles,
+      createdAt: task.createdAt,
+      updatedAt: task.updatedAt,
+    }));
   }
 }
 


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용
- getMyTasks 메서드에서 조회한 Task 데이터를 응답 전에 가공하는 로직 추가
- 날짜 필드(startedAt, dueDate)를 연/월/일로 분리하여 startYear, startMonth, startDay, endYear, endMonth, endDay 형태로 변환
- 관계 데이터(user, taskTags, taskFiles)를 포함하여 클라이언트에서 바로 사용 가능하도록 응답 구조 개선

## ❔ 이유
- 칸반, 캘린더 보드에 날짜 데이터가 들어가지 않은 현상이 발견되어 수정하였습니다.

## 💬 리뷰어에게
- 확인해주셔서 감사합니다 :)