### PR TITLE
feat: 프로젝트 접근 권한 체크 미들웨어 추가 및 적용

### DIFF
--- a/src/middlewares/authorization.ts
+++ b/src/middlewares/authorization.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function authorization(req: Request, res: Response, next: NextFunction) {
+  const userId = req.user?.id;
+  const projectId = Number(req.params.projectId);
+
+  if (!userId) {
+    return res.status(401).json({ message: '로그인이 필요합니다.' });
+  }
+
+  if (isNaN(projectId)) {
+    return res.status(400).json({ message: '유효하지 않은 프로젝트 ID입니다.' });
+  }
+
+  try {
+    const isMember = await prisma.project_members.findFirst({
+      where: { projectId, userId },
+    });
+
+    if (!isMember) {
+      return res.status(403).json({ message: '프로젝트 접근 권한이 없습니다.' });
+    }
+
+    next();
+  } catch (error) {
+    console.error('authorization error:', error);
+    res.status(500).json({ message: '서버 오류가 발생했습니다.' });
+  }
+}

--- a/src/routes/project-route.ts
+++ b/src/routes/project-route.ts
@@ -7,36 +7,44 @@ import {
   deleteProject,
 } from '../controllers/project-controller';
 import { createTaskController, getAllTasksController } from '../controllers/task-controller';
+import { authorization } from '../middlewares/authorization';
 
 const router = express.Router();
 
 router.post('/', passport.authenticate('access-token', { session: false }), createProject);
 
-router.get('/:projectId', passport.authenticate('access-token', { session: false }), getProject);
+router.get(
+  '/:projectId',
+  passport.authenticate('access-token', { session: false }),
+  authorization,
+  getProject
+);
 
 router.patch(
   '/:projectId',
   passport.authenticate('access-token', { session: false }),
+  authorization,
   updateProject
 );
 
 router.delete(
   '/:projectId',
   passport.authenticate('access-token', { session: false }),
+  authorization,
   deleteProject
 );
 
-// 할 일 생성
 router.post(
   '/:projectId/tasks',
   passport.authenticate('access-token', { session: false }),
+  authorization,
   createTaskController
 );
 
-// 할 일 전체 목록 조회
 router.get(
   '/:projectId/tasks',
   passport.authenticate('access-token', { session: false }),
+  authorization,
   getAllTasksController
 );
 


### PR DESCRIPTION
<!-- 제목 예시: feat: 유저 생성 API 구현  -->
<!-- 규칙 -->
<!-- PR 메세지는 자세히 작성한다. -->
<!-- 어떤 변경사항이 있고, 어떤 이유로 어떤 것을 어떻게 작업했다. -->

## ✨ 변경 내용  
- 프로젝트 관련 API 접근 시, 해당 프로젝트의 멤버인지 권한 검증하는 `authorization` 미들웨어를 추가 및 적용  
- JWT 인증 후 `authorization` 미들웨어가 `req.user.id`와 `req.params.projectId`를 확인하여 비멤버의 접근을 차단하도록 구현  
- 프로젝트 생성 API는 권한 체크 제외, 나머지 프로젝트 조회/수정/삭제 및 태스크 관련 API에 권한 검사 적용  
- 권한 미들웨어에서 Prisma Client를 사용해 프로젝트 멤버 여부를 조회하도록 구현  

## ❔ 이유  
- URL에 임의로 프로젝트 ID를 입력해도 멤버가 아니면 접근할 수 없는 보안 취약점을 해결하기 위해  
- 인증은 되어 있지만, 자원에 대한 접근 권한(인가)이 빠져 있어 데이터 유출 가능성을 차단하기 위함  

## 💬 리뷰어에게  
- 미들웨어가 올바르게 작동하는지, 비멤버 접근 시 적절한 에러 응답이 반환되는지 확인 부탁드립니다.  
- Prisma Client 재사용 및 미들웨어 위치 관련하여 개선할 점이 있으면 피드백 부탁드립니다.  